### PR TITLE
fix: increase RSS parser timeout from 10s to 30s to handle slower feeds

### DIFF
--- a/src/rss-parser.ts
+++ b/src/rss-parser.ts
@@ -9,7 +9,7 @@ export class RSSFeedParser {
 
   constructor() {
     this.parser = new Parser({
-      timeout: 10000,
+      timeout: 30000,
       headers: {
         'User-Agent': 'CyberSecurity-RSS-MCP-Server/1.0'
       }
@@ -75,7 +75,7 @@ export class RSSFeedParser {
       }
 
       const controller = new AbortController();
-      const timeoutId = setTimeout(() => controller.abort(), 10000);
+      const timeoutId = setTimeout(() => controller.abort(), 30000);
       
       const response = await fetch(url, {
         headers: {


### PR DESCRIPTION
Fixes Microsoft Security Blog feed timeout errors by increasing the RSS parser timeout from 10 seconds to 30 seconds.

**Changes:**
- Increased main RSS parser timeout from 10000ms to 30000ms
- Updated fetchFullArticle timeout to match (30000ms)

Fixes #2

Generated with [Claude Code](https://claude.ai/code)