### PR TITLE
Update Palo Alto Unit 42 feed URL to feedburner

### DIFF
--- a/src/feeds.ts
+++ b/src/feeds.ts
@@ -9,7 +9,7 @@ export const CYBERSECURITY_FEEDS: CyberSecurityFeed[] = [
   },
   {
     name: "Palo Alto - Unit 42",
-    url: "https://researchcenter.paloaltonetworks.com/unit42/feed/",
+    url: "http://feeds.feedburner.com/Unit42",
     description: "Palo Alto - Unit 42",
     category: "research"
   },


### PR DESCRIPTION
Updates the Palo Alto Unit 42 feed URL from the old research center URL to the new feedburner URL as requested in issue #4.

Changes:
- Update feed URL in `src/feeds.ts`
- Maintains same feed name and description
- Feed should be parseable by existing RSSFeedParser

Resolves #4

Generated with [Claude Code](https://claude.ai/code)